### PR TITLE
Add full schedule feed to OBS feeds.

### DIFF
--- a/webpages/module/obs/feeds.php
+++ b/webpages/module/obs/feeds.php
@@ -95,6 +95,16 @@ function showObsFeedOptions(): void
         . $_SERVER['SERVER_NAME'];
     $result = mysqli_query_with_error_handling($query);
     echo "<ul>";
+
+    $filename = makeFileName('full', 'schedule');
+    $filepath = OBS_EXTRACT_DIRECTORY . '/' . $filename;
+    writeObsFullScheduleFile(
+        $rootDir . '/' . $filepath,
+        ['full' => 'schedule'],
+        $participants
+    );
+    echo "<li><a href=\"/$filepath\">$baseUrl/$filepath</a></li>";
+
     while ($row = mysqli_fetch_object($result)) {
         $filename = makeFileName('room', $row->roomname);
         $filepath = OBS_EXTRACT_DIRECTORY . '/' . $filename;

--- a/webpages/module/obs/obs_functions.php
+++ b/webpages/module/obs/obs_functions.php
@@ -15,6 +15,21 @@
 require_once __DIR__ . '/../../db_functions.php';
 
 /**
+ * Write file for full schedule.
+ *
+ * @param string $filepath     The file to write to.
+ * @param array  $fileTags     Array of top level file tags such as room name.
+ * @param array  $participants Array of participants per session.
+ *
+ * @return void
+ */
+function writeObsFullScheduleFile(string $filepath, array  $fileTags, array $participants): void
+{
+    $json = json_encode(getObsData("1=1", $participants, $fileTags));
+    writeJsonFile($filepath, $json);
+}
+
+/**
  * Write file for room.
  *
  * @param int    $roomId       The room identifier.


### PR DESCRIPTION
Currently the OBS module can create individual room feeds, and it can create per tag feeds, but it does not create a full schedule feed. This adds a full schedule feed extract.